### PR TITLE
Fix avatar upload parameter name mismatch

### DIFF
--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -51,7 +51,7 @@ export async function getCurrentUser(): Promise<User | null> {
 
 export async function uploadAvatar(file: File): Promise<UploadAvatarResponse> {
   const formData = new FormData();
-  formData.append('avatar', file);
+  formData.append('file', file);
 
   return apiClient.uploadFile('user/avatar', formData);
 }


### PR DESCRIPTION
- Change FormData parameter name from 'avatar' to 'file' to match backend endpoint
- Fixes avatar upload functionality by ensuring parameter names match between frontend and backend