### PR TITLE
fix: resolve dashboard refresh authentication and tasks rendering issues

### DIFF
--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -45,6 +45,17 @@ export async function getCurrentUser(): Promise<User | null> {
     return data.currentUser;
   } catch (error) {
     console.error('Failed to fetch current user:', error);
+
+    // If this is an authentication error, rethrow it so the auth store can handle it
+    if (error instanceof Error && (
+      error.message.includes('Authentication error') ||
+      error.message.includes('Unauthorized') ||
+      error.message.includes('401')
+    )) {
+      throw error;
+    }
+
+    // For other errors (network, server errors), return null but don't fail completely
     return null;
   }
 }

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -11,6 +11,15 @@
   let bulkOperationLoading = false;
   let bulkOperationError = '';
 
+  onMount(async () => {
+    // Load tasks when component mounts
+    try {
+      await tasksStore.load();
+    } catch (error) {
+      console.error('Failed to load tasks:', error);
+    }
+  });
+
   // Reactive bulk actions visibility
   $: showBulkActions = $selectedTaskIds.size > 0;
 

--- a/src/lib/services/websocket.ts
+++ b/src/lib/services/websocket.ts
@@ -92,11 +92,9 @@ class WebSocketService {
 
 export const webSocketService = new WebSocketService();
 
+// Only auto-connect if explicitly requested and authenticated
+// Connection should be managed by the auth store and layout component
 if (typeof window !== 'undefined') {
-  setTimeout(() => {
-    webSocketService.connect();
-  }, 100);
-
   window.addEventListener('beforeunload', () => {
     webSocketService.disconnect();
   });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,19 +10,9 @@
 
   onMount(() => {
     auth.initialize();
-    
-    // Initialize WebSocket connection when user is authenticated
-    const unsubscribe = auth.subscribe((authState) => {
-      if (authState.isAuthenticated) {
-        console.log('User authenticated, connecting WebSocket');
-        webSocketService.connect();
-      } else {
-        console.log('User not authenticated, disconnecting WebSocket');
-        webSocketService.disconnect();
-      }
-    });
 
-    return unsubscribe;
+    // WebSocket connection is now handled automatically in the auth store
+    // after successful authentication initialization
   });
 
   onDestroy(() => {


### PR DESCRIPTION
- Add currentUser GraphQL query to backend (UserController.java, schema.graphqls)
- Fix authentication error handling in frontend to properly handle 400 errors
- Improve WebSocket connection management to only connect after successful auth
- Add onMount task loading to KanbanBoard component to ensure tasks render
- Enhance error differentiation between network errors and auth failures
- Clean up debugging logs for production readiness

Fixes:
- Dashboard page refresh no longer redirects to login
- Tasks now properly load and display in KanbanBoard
- WebSocket connects only after successful authentication
- Better error handling for expired/invalid tokens

Resolves: Dashboard refresh authentication issue